### PR TITLE
[FRONTEND] feat: Creación menú inferior y lateral. Closes #47

### DIFF
--- a/frontend/src/components/BottomNav.vue
+++ b/frontend/src/components/BottomNav.vue
@@ -1,0 +1,48 @@
+<template>
+  <nav class="fixed bottom-0 left-0 w-full bg-white dark:bg-background shadow-lg z-50 border-t border-gray-200 dark:border-zinc-700 rounded-t-3xl pt-2">
+    <ul class="flex justify-around items-center h-20 px-4">
+      <li v-for="item in navItems" :key="item.route">
+        <button
+          @click="router.push(item.route)"
+          class="flex flex-col items-center justify-center text-xs transition-all duration-300 hover:scale-105 active:scale-95"
+        >
+          <component
+            :is="item.icon"
+            :class="[
+              'w-6 h-6 transition-all duration-200 mb-1',
+              route.path === item.route ? 'text-primary scale-110 drop-shadow-sm' : 'text-gray-400'
+            ]"
+          />
+          <span :class="route.path === item.route ? 'text-primary font-medium' : 'text-gray-400'">
+            {{ item.label }}
+          </span>
+        </button>
+      </li>
+    </ul>
+  </nav>
+</template>
+
+<script setup>
+import { useRouter, useRoute } from 'vue-router'
+import { Home, Target, User, Trophy } from 'lucide-vue-next'
+
+const router = useRouter()
+const route = useRoute()
+
+const navItems = [
+  { label: 'Inicio', route: '/dashboard', icon: Home },
+  { label: 'Misiones', route: '/missions', icon: Target },
+  { label: 'Logros', route: '/achievements', icon: Trophy },
+  { label: 'Perfil', route: '/profile', icon: User },
+]
+</script>
+
+<style scoped>
+nav {
+  border-top-left-radius: 1.5rem;
+  border-top-right-radius: 1.5rem;
+}
+button:focus {
+  outline: none;
+}
+</style>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,0 +1,79 @@
+<template>
+  <Transition name="slide">
+    <aside
+      v-if="isSidebarOpen"
+      class="fixed top-0 left-0 w-64 h-full bg-white dark:bg-background shadow-lg z-50 flex flex-col p-4"
+    >
+      <div class="flex items-center justify-between mb-6">
+        <h2 class="text-lg font-semibold text-text">Menú</h2>
+        <button @click="isSidebarOpen = false">
+          <X class="w-6 h-6 text-text" />
+        </button>
+      </div>
+
+      <ul class="flex flex-col gap-4">
+        <li v-for="item in links" :key="item.route">
+          <button
+            @click="navigate(item.route)"
+            class="flex items-center gap-2 text-sm text-left text-text w-full hover:text-primary transition"
+          >
+            <component :is="item.icon" class="w-5 h-5" />
+            {{ item.label }}
+          </button>
+        </li>
+      </ul>
+
+      <button
+        @click="logout"
+        class="mt-auto text-sm text-left text-red-500 hover:underline"
+      >
+        Cerrar sesión
+      </button>
+    </aside>
+  </Transition>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { X, List, LogOut, Home, Trophy, User, Target } from 'lucide-vue-next'
+import { toast } from 'vue3-toastify'
+
+const router = useRouter()
+const isOpen = ref(false)
+
+const links = [
+  { label: 'Misiones completadas', route: '/missions/completed', icon: Target },
+  { label: 'Estadísticas', route: '/user/stats', icon: Trophy },
+  { label: 'Perfil', route: '/profile', icon: User },
+]
+
+function navigate(routePath) {
+  isOpen.value = false
+  router.push(routePath)
+}
+
+function logout() {
+  localStorage.removeItem('token')
+  toast.success('Has cerrado sesión')
+  router.push('/login')
+  toggleSidebar(false)
+}
+
+import { isSidebarOpen, toggleSidebar } from '@/composables/useSidebar'
+
+</script>
+<style scoped>
+.slide-enter-active, .slide-leave-active {
+  transition: transform 0.3s ease;
+}
+.slide-enter-from {
+  transform: translateX(-100%);
+}
+.slide-enter-to, .slide-leave-from {
+  transform: translateX(0);
+}
+.slide-leave-to {
+  transform: translateX(-100%);
+}
+</style>

--- a/frontend/src/composables/useSidebar.js
+++ b/frontend/src/composables/useSidebar.js
@@ -1,0 +1,7 @@
+import { ref } from 'vue'
+
+export const isSidebarOpen = ref(false)
+
+export function toggleSidebar(state = true) {
+  isSidebarOpen.value = state
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -10,17 +10,17 @@ import 'vue3-toastify/dist/index.css'
 // Tu CSS
 import './style.css'
 
-const app = createApp(App)
-
-createApp(App).use(router).mount('#app')
-
 const toastOptions: ToastContainerOptions = {
   autoClose: 3000,
   position: 'top-center',
   theme: 'dark',
 }
 
+const app = createApp(App)
+
 app.use(router)
 app.use(createPinia())
 app.use(Vue3Toastify, toastOptions)
+
 app.mount('#app')
+

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -12,20 +12,40 @@ import MissionsView from '@/views/MissionsView.vue'
 import CompletedMissionsView from '@/views/CompletedMissionsView.vue'
 import AchievementsView from '@/views/AchievementsView.vue'
 import ProfileView from '@/views/ProfileView.vue'
+import AppLayout from '@/views/AppLayout.vue'
+
 
 const routes = [
-  { path: '/',         name: 'Landing',  component: LandingView },
-  { path: '/login',    name: 'Login',    component: LoginView },
+  // Redirección base
+  {
+    path: '/',
+    redirect: () => {
+      return isAuthenticated() ? '/dashboard' : '/landing'
+    }
+  },
+  // Vistas públicas
+  { path: '/landing', name: 'Landing', component: LandingView },
+  { path: '/login', name: 'Login', component: LoginView },
   { path: '/register', name: 'Register', component: RegisterView },
   { path: '/reset-password', name: 'ResetPassword', component: ResetPasswordView },
   { path: '/reset-password/:token', name: 'ResetPasswordToken', component: ResetPasswordTokenView },
-  { path: '/dashboard', name: 'Dashboard', component: DashboardView, meta: { requiresAuth: true } },
-  { path: '/user/stats', name: 'UserStats', component: UserStatsView, meta: { requiresAuth: true } },
-  { path: '/missions', name: 'Missions', component: MissionsView, meta: { requiresAuth: true } },
-  { path: '/missions/completed', name: 'CompletedMissions', component: CompletedMissionsView, meta: { requiresAuth: true } },
-  { path: '/achievements', name: 'Achievements', component: AchievementsView, meta: { requiresAuth: true } },
-  { path: '/profile', name: 'Profile', component: ProfileView, meta: { requiresAuth: true } }
+
+  // Rutas protegidas con layout
+  {
+    path: '/',
+    component: AppLayout,
+    meta: { requiresAuth: true },
+    children: [
+      { path: 'dashboard', name: 'Dashboard', component: DashboardView },
+      { path: 'missions', name: 'Missions', component: MissionsView },
+      { path: 'missions/completed', name: 'CompletedMissions', component: CompletedMissionsView },
+      { path: 'user/stats', name: 'UserStats', component: UserStatsView },
+      { path: 'achievements', name: 'Achievements', component: AchievementsView },
+      { path: 'profile', name: 'Profile', component: ProfileView }
+    ]
+  }
 ]
+
 const router = createRouter({
   history: createWebHistory(),
   routes,

--- a/frontend/src/views/AppLayout.vue
+++ b/frontend/src/views/AppLayout.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="min-h-screen w-screen bg-background text-text flex flex-col pb-16">
+    <header class="flex items-center justify-between p-4">
+      <button @click="toggleSidebar(true)">
+        <Menu class="w-6 h-6 text-text" />
+      </button>
+    </header>
+
+    <router-view />
+    <BottomNav />
+    <Sidebar />
+  </div>
+</template>
+
+<script setup>
+import BottomNav from '@/components/BottomNav.vue'
+import Sidebar from '@/components/Sidebar.vue'
+import { toggleSidebar } from '@/composables/useSidebar'
+import { Menu } from 'lucide-vue-next'
+</script>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -12,5 +12,5 @@
 
 
 <script setup>
-import LogoutButton from '@/components/LogoutButton.vue'
+import bottomnav from '@/components/BottomNav.vue'
 </script>


### PR DESCRIPTION
## Creación de menú inferior y lateral.

### Menú inferior
- Componente `<BottomNav />` con navegación inferior fija
- Iconos interactivos con escala y color activo
- Soporte completo para dark mode
- Integrado en `AppLayout.vue` para rutas autenticadas

![image](https://github.com/user-attachments/assets/c83223a9-63f3-4593-bccb-c276e3d73cec)

### Menú lateral
- Componente `<Sidebar />` con animación de deslizamiento lateral
- Botón hamburguesa superior izquierdo para abrirlo
- Enlaces extendidos: Misiones completadas, Estadísticas, Perfil
- Botón de cerrar sesión con cierre automático del menú

![image](https://github.com/user-attachments/assets/5ee1361b-1fa7-43a3-aa3d-dcb5303d17c9)

### Estado global con composable
- Creado `useSidebar.js` para manejar `isSidebarOpen` global
- Importado y utilizado en `AppLayout` y `Sidebar`

### Router y estructura
- Agrupación de rutas privadas bajo `AppLayout.vue`
- Redirección desde `/`:
  - ✅ Si hay token → `/dashboard`
  - ❌ Si no hay sesión → `/landing`